### PR TITLE
Added PublishTrimmed to Impostor.Server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build Impostor.Client
         run: msbuild ./src/Impostor.Client/Impostor.Client.csproj /p:Configuration=Release
       - name: Build Impostor.Server
-        run: dotnet build --no-restore -c Release -f netcoreapp3.1 ./src/Impostor.Server/Impostor.Server.csproj
+        run: dotnet build --no-restore -c Release -f netcoreapp3.1 ./src/Impostor.Server/Impostor.Server.csproj -p:PublishTrimmed=false
       - name: Test
         run: dotnet test --no-restore -v normal -f netcoreapp3.1 ./src
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN dotnet restore -r linux-musl-x64 ./src/Impostor.Server/Impostor.Server.cspro
 # Copy everything else.
 COPY submodules/. ./submodules/
 COPY src/. ./src/
-RUN dotnet publish -c release -o /app -f netcoreapp3.1 -r linux-musl-x64 --self-contained false --no-restore ./src/Impostor.Server/Impostor.Server.csproj
+RUN dotnet publish -c release -o /app -r linux-musl-x64 --no-restore ./src/Impostor.Server/Impostor.Server.csproj
 
 # Final image.
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1-alpine
 WORKDIR /app
 COPY --from=build /app ./
 EXPOSE 22023/udp

--- a/src/Impostor.Server/Impostor.Server.csproj
+++ b/src/Impostor.Server/Impostor.Server.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <RuntimeIdentifiers>win-x64;linux-x64;linux-musl-x64</RuntimeIdentifiers>
+        <PublishTrimmed>true</PublishTrimmed>
         <AssemblyTitle>Impostor.Server</AssemblyTitle>
         <Product>Impostor.Server</Product>
         <Copyright>Copyright © AeonLucid 2020</Copyright>


### PR DESCRIPTION
Added `<PublishTrimmed>true</PublishTrimmed>` to trim the release with IL Linker. More information can be found [here](https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-self-contained).

**Size before trimming:** 66.4 MB
**Size after trimming:** 32.3 MB

I've tested the following: creating lobby, joining game, chatting, mini-games, finishing game and returning to lobby. Everything seems to be working fine and no required dependencies are being trimmed.

**Edit:** I've changed the Dockerfile as well so it supports trimming.

**Docker image size before:** 106MB
**Docker image size after:** 53.4MB