### PR TITLE
Improved Windows instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
         <section class="container">
             <div class="mb-4 mb-md-3">
                 <h3 class="text-center text-md-left mb-4 mb-md-3 w-100">Connect to a Server</h3>
-                <p class="text-justify text-sm-center text-md-left support-text desktop-support">To play on a private server, type the server IP and overwrite the <b>regionInfo.dat</b> file in <b>C:\Users\YOUR USER\AppData\LocalLow\Innersloth\Among Us</b>.</p>
                 <p class="text-justify text-sm-center text-md-left support-text android-support">To play on a private server, type the server IP and overwrite the <b>regionInfo.dat</b> file in <b>Internal Storage/Android/data/com.innersloth.spacemafia/files</b>.</p>
                 <p class="text-justify text-sm-center text-md-left support-text ios-support">Your iPhone must be jailbroken to overwrite the <b>regionInfo.dat</b> in the game folder.</p>
             </div>
@@ -39,6 +38,27 @@
                     <button class="btn btn-primary btn-lg">Download server file</button>
                 </div>
             </form>
+            <div class="support-text desktop-support mt-4">
+                <h3>Instructions</h3>
+                <p class="text-justify text-sm-center text-md-left">
+                    To play on a private server follow the following steps:
+                    <ol>
+                        <li>Type the server IP and download click the button "Download server file".</li>
+                        <li>Make sure that the file is named <code>regionInfo.dat</code> and doesn't have additional numbers (e.g. <code>regionInfo (1).dat</code>) because you downloaded it multiple times.</li>
+                        <li>
+                            Press <kbd class="key"><svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="windows" class="svg-inline--fa fa-windows fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"></path></svg></kbd> + <kbd class="key">R</kbd> on your keyboard and paste the following:<br />
+                            <div class="text-center my-2">
+                                <code>%APPDATA%\..\LocalLow\Innersloth\Among Us</code>
+                            </div>
+                        </li>
+                        <li>Press <span class="key">Enter</span> or click "OK".</li>
+                        <li>Copy the downloaded file and paste it in the opened folder.</li>
+                        <li>You can now play on your server by opening Among Us and clicking "Online".</li>
+                    </ol>
+                    To switch back to the original servers, change the region in the bottom right corner.<br />
+                    If you want to switch back to your server, re-do the steps above.
+                </p>
+            </div>
         </section>
 
 

--- a/style.css
+++ b/style.css
@@ -37,3 +37,22 @@ body {
     display: none;
     word-break: break-all;
 }
+
+.key {
+    display: inline-block;
+    padding: 5px;
+    border-radius: 5px;
+    border: solid 1px white;
+    min-width: 1.75rem;
+    text-align: center;
+    font-size: 0.8rem;
+    margin: 0.15rem 0;
+}
+
+.key svg {
+    height: 1.25em;
+}
+
+code {
+    white-space: nowrap;
+}


### PR DESCRIPTION
I've changed the instructions a little bit for desktop. Instead of showing the path it shows how to get there instantly. This is because the AppData folder is hidden by default, which can be quite confusing for gamers that haven't played Minecraft.

Please check for any spelling mistakes because I'm quite good at those 😅

**Before:**
![image](https://user-images.githubusercontent.com/2109929/94349188-aae66700-0042-11eb-9a3c-05a263d81c9c.png)

**After:**
![image](https://user-images.githubusercontent.com/2109929/94349192-b46fcf00-0042-11eb-94d9-df5856759178.png)

